### PR TITLE
Add event status setup when it becomes active

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipelinePythonSCA(
     pythonVersion: '3.6',
     packages: ['.'],
     runUnitTests: false,
-    runBlack: false,
+    runBlack: true,
     runIsort: false,
     installFromSetup: true,
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipelinePythonSCA(
     pythonVersion: '3.6',
     packages: ['.'],
     runUnitTests: false,
-    runBlack: true,
+    runBlack: false,
     runIsort: false,
     installFromSetup: true,
 )

--- a/oadr2/event.py
+++ b/oadr2/event.py
@@ -337,7 +337,6 @@ class EventHandler(object):
 
         return active
 
-
     def remove_events(self, evt_id_list):
         '''
         Remove a list of events from our internal member dictionary
@@ -360,6 +359,18 @@ class EventHandler(object):
             return  # optout of not existing event
 
         self.optouts.add(e_id)
+
+    def update_active_status(self, event_id):
+        '''
+        Update given event status
+
+        :param event_id:
+        :return:
+        '''
+        event = self.db.get_event(event_id)
+        if event and event.status in ["near", "far"]:
+            event.status = "active"
+            self.db.update_event(event)
 
 
 def get_current_signal_value(evt, ns_map=NS_A):

--- a/oadr2/poll.py
+++ b/oadr2/poll.py
@@ -172,7 +172,8 @@ class OpenADR2(base.BaseHandler):
                 event_uri,
                 cert=self.ven_certs,
                 verify=self.vtn_ca_certs,
-                data=etree.tostring(payload)
+                data=etree.tostring(payload),
+                auth=(self.__username, self.__password) if self.__username or self.__password else None
             )
         except Exception as ex:
             logging.warning("Connection failed: %s", ex)
@@ -213,7 +214,8 @@ class OpenADR2(base.BaseHandler):
             cert=self.ven_certs,
             verify=self.vtn_ca_certs,
             data=etree.tostring(payload),
-            timeout=REQUEST_TIMEOUT
+            timeout=REQUEST_TIMEOUT,
+            auth=(self.__username, self.__password) if self.__username or self.__password else None
         )
 
         logging.debug("EiEvent response: %s", resp.status_code)

--- a/oadr2/schemas.py
+++ b/oadr2/schemas.py
@@ -110,6 +110,8 @@ class EventSchema(BaseModel):
     def cancel(self, random_end=False):
         if self.status == "active" or random_end:
             self.end = schedule.random_offset(datetime.utcnow(), 0, self.cancellation_offset) if self.cancellation_offset else datetime.utcnow()
+        elif self.status == "cancelled":
+            pass
         else:
             self.end = datetime.utcnow()
         self.status = "cancelled"
@@ -142,7 +144,13 @@ class EventSchema(BaseModel):
         event_start = schedule.random_offset(event_original_start, *start_offset)
 
         event_duration = EventSchema.get_active_period_duration(evt_xml)[0]
-        ending_time = event_duration + event_start if bool(event_duration) else None
+        if bool(event_duration):
+            if event_status == "cancelled":
+                ending_time = event_start
+            else:
+                ending_time = event_duration + event_start
+        else:
+            ending_time = None
         event_test = EventSchema.get_test_event(evt_xml)
 
         return EventSchema(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name = 'oadr2-ven',
-    version = '0.7',
+    version = '0.8',
     description = 'OpenADR 2.0a VEN for Python',
     author = 'EnerNOC Advanced Technology',
     author_email = 'tnichols@enernoc.com',


### PR DESCRIPTION
This patch adds better handling of event status when receiving cancelled event or when event becomes active.

When event becomes active we need to locally update its status so if it later gets cancelled with randomized ending time, that time will be calculated correctly. This is specifically to cover issue when event started, but VTN sends update with status still not changed to "active" 